### PR TITLE
Update notes, revert dependency on pybloom_live

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,7 +2,7 @@
 Installation
 ============
 
-At the command line::
+If you already have virtual-environment and python-dev set up::
 
     pip install zentropi
 
@@ -37,16 +37,15 @@ that are needed by Zentropi.
 
 ::
 
-    $ sudo apt install gcc libssl-dev python3-dev python3-setuptools
-
+    $ sudo apt install gcc libssl-dev python3-dev python3-setuptools python3-venv
 
 
 3. Install and create venv
 --------------------------
 ::
 
-    $ sudo apt install python3-venv
     $ python3 -m venv zen
+
 
 This creates a python virtual-environment, which keeps your installed
 libraries separate from rest of the system.
@@ -57,6 +56,19 @@ libraries separate from rest of the system.
 ::
 
     $ source zen/bin/activate
+
+
+You will need to `activate` the zen virtual-environment before working
+with zentropi. A shortcut would be to add an alias to your ``~/.profile``
+or ``~/.bash_profile``:
+
+::
+
+    alias zen="source /path/to/zen/bin/activate"
+
+
+You can run ``source ~/.profile`` or open a new terminal window
+and type ``zen`` to activate the virtual-environment.
 
 5. Install zentropi
 -------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -41,20 +41,25 @@ that are needed by Zentropi.
 
 
 
-3. Install and create a venv (python virtual-environment)
-
+3. Install and create venv
+--------------------------
 ::
 
     $ sudo apt install python3-venv
     $ python3 -m venv zen
 
+This creates a python virtual-environment, which keeps your installed
+libraries separate from rest of the system.
+
 4. Activate the venv
+--------------------
 
 ::
 
     $ source zen/bin/activate
 
 5. Install zentropi
+-------------------
 
 ::
 

--- a/setup.py
+++ b/setup.py
@@ -71,11 +71,11 @@ setup(
         'pub-sub',
     ],
     install_requires=[
-        'bloom_filter >= 1.3, <2.0'
         'click>=6.7, <7.0',
         'fuzzywuzzy>=0.15.0, <0.20',
         'parse>=1.8.0, <2.0',
         'prompt_toolkit==1.0.14, <1.1',
+        'pybloom_live>=2.2.0, <2.3',
         'Pygments>=2.2.0, <2.3',
         'python-Levenshtein>=0.12.0',
         'sortedcontainers>=1.5.7, <1.6',

--- a/src/zentropi/agent.py
+++ b/src/zentropi/agent.py
@@ -8,7 +8,7 @@ from typing import (
     Union,
 )
 
-from bloom_filter import BloomFilter
+from pybloom_live import ScalableBloomFilter
 
 from zentropi.frames import Frame
 from zentropi.handlers import Handler
@@ -30,7 +30,8 @@ class Agent(Zentropian):
         self.states.running = False
         self.loop = None  # asyncio.get_event_loop()
         self._spawn_on_start = set()
-        self._seen_frames = BloomFilter(max_elements=10000, error_rate=0.001)
+        self._seen_frames = ScalableBloomFilter(
+                    mode=ScalableBloomFilter.LARGE_SET_GROWTH, error_rate=0.001)
 
     @on_state('should_stop')
     def _on_should_stop(self, state):


### PR DESCRIPTION
Even though there are no immediate failures, sticking with a known-good library; also because this library alone does not demand python-dev, parse needs it too. Will experiment more and then decide.